### PR TITLE
Make sdl2 platform compatible with apple silicon

### DIFF
--- a/dependencies/minizip/ioapi.c
+++ b/dependencies/minizip/ioapi.c
@@ -14,6 +14,12 @@
         #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#if defined(__APPLE__)
+#define fopen64 fopen
+#define ftello64 ftello
+#define fseeko64 fseeko
+#endif
+
 #include "ioapi.h"
 
 voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,const void*filename,int mode)

--- a/platform/sdl2/makefile
+++ b/platform/sdl2/makefile
@@ -8,7 +8,7 @@ WINTARGET = PokeMini.exe
 WINRES_TRG = $(BUILD)/pokemini_rc.o
 WINRES_SRC = $(POKEROOT)resource/pokemini.rc
 
-CFLAGS += -Wall -g `$(SDL_BASE)sdl2-config --cflags` $(INCLUDE)
+CFLAGS += -Wall `$(SDL_BASE)sdl2-config --cflags` $(INCLUDE)
 SLFLAGS += `$(SDL_BASE)sdl2-config --libs` -lm -lz
 
 INCDIRS = source sourcex resource freebios dependencies/minizip

--- a/platform/sdl2/makefile
+++ b/platform/sdl2/makefile
@@ -8,7 +8,7 @@ WINTARGET = PokeMini.exe
 WINRES_TRG = $(BUILD)/pokemini_rc.o
 WINRES_SRC = $(POKEROOT)resource/pokemini.rc
 
-CFLAGS += -Wall `$(SDL_BASE)sdl2-config --cflags` $(INCLUDE)
+CFLAGS += -Wall -g `$(SDL_BASE)sdl2-config --cflags` $(INCLUDE)
 SLFLAGS += `$(SDL_BASE)sdl2-config --libs` -lm -lz
 
 INCDIRS = source sourcex resource freebios dependencies/minizip
@@ -120,5 +120,4 @@ win:
 	make -f makefile.win
 
 clean:
-	-rm -f $(BUILDOBJS) $(TARGET) $(WINTARGET) $(WINRES_TRG)
-	-rmdir --ignore-fail-on-non-empty $(BUILD)
+	-rm -rf $(BUILDOBJS) $(TARGET) $(WINTARGET) $(WINRES_TRG) $(BUILD)

--- a/source/PokeMini.c
+++ b/source/PokeMini.c
@@ -572,7 +572,7 @@ int PokeMini_CheckSSFile(const char *statefile, char *romfile)
 		return 0;
 	}
 	PMiniStr[127] = 0;
-	if (romfile) strcpy(romfile, PMiniStr);
+	if (romfile) memmove(romfile, PMiniStr, strlen(PMiniStr) + 1);
 	fclose(fi);
 
 	return 1;
@@ -722,7 +722,7 @@ int PokeMini_SaveSSFile(const char *statefile, const char *romfile)
 	PMiniID = PokeMini_ID;
 	fwrite(&PMiniID, 1, 4, fo);	// Write State ID
 	memset(PMiniStr, 0, 128);
-	strcpy(PMiniStr, romfile);
+  memmove(PMiniStr, romfile, strlen(romfile) + 1);
 	fwrite(PMiniStr, 1, 128, fo);	// Write ROM related to state
 	StatTime = Endian32((uint32_t)time(NULL));
 	fwrite(&StatTime, 1, 4, fo);	// Write Time
@@ -912,7 +912,7 @@ static int PokeMini_iLoadROMZip(const char *zipfile, int *colorloaded)
 			}
 		}
 		// Filename based of the zip
-		strcpy(filein, zipfile);
+		memmove(filein, zipfile, strlen(zipfile) + 1);
 		RemoveExtension(filein);
 		strcat(filein, ".minc");
 		if (FileExist(filein)) {
@@ -946,21 +946,21 @@ int PokeMini_LoadROM(const char *filename)
 	if (ExtensionCheck(filename, ".zip")) {
 		// Load new MIN ROM and Color Information inside zip
 		if (!PokeMini_iLoadROMZip(filename, &colorloaded)) return 0;
-		strcpy(CommandLine.min_file, filename);
+    memmove(CommandLine.min_file, filename, strlen(filename) + 1);
 	} else
 #endif
  	{
 		// Setup LCD mode based of color support
 		if (ExtensionCheck(filename, ".minc")) {
 			// Remove c and load new MIN ROM
-			strcpy(tmp, filename);
+      memmove(tmp, filename, strlen(filename) + 1);
 			tmp[strlen(filename)-1] = 0;
 			if (!PokeMini_LoadMINFile(tmp)) return 0;
-			strcpy(CommandLine.min_file, tmp);
+      memmove(CommandLine.min_file, tmp, strlen(tmp) + 1);
 		} else {
 			// Load new MIN ROM
 			if (!PokeMini_LoadMINFile(filename)) return 0;
-			strcpy(CommandLine.min_file, filename);
+      memmove(CommandLine.min_file, filename, strlen(filename) + 1);
 		}
 
 		// Load Color Information


### PR DESCRIPTION
### large file handling

Mac doesn't (seem to) support `fopen64`, `ftello64`, or `fseeko64`, so use `#define` to switch to the supported versions (`fopen`, `ftello`, and `fseeko`).

There's a stackoverflow answer https://stackoverflow.com/questions/4003479/how-to-enable-large-file-support-under-darwin that claims that this code should just use `fopen`/`ftello`/`fseeko` by default instead of the large file `fWHATEVER64` versions, so it would be easy modify this PR to switch all instance of `fWHATEVER64` to `fWHATEVER`. 

### makefile

Use rm -rf on all created files instead of  rmdir --ignore-fail-on-non-empty Build

### strcpy->memmove

I was getting `SIGTRACE`s because the `str`s in the `strcpy` operations had overlap and `memmove` is safer. 