### PR TITLE
Tweak debug platform to work on macos

### DIFF
--- a/platform/debug/PokeMini_Debug.c
+++ b/platform/debug/PokeMini_Debug.c
@@ -770,8 +770,8 @@ int main(int argc, char **argv)
 		CPUWindow_FrameRendered();
 
 		// Handle events
-		while (SDL_PollEvent(&event)) handleevents(&event);
 		while (gtk_events_pending()) gtk_main_iteration();
+		while (SDL_PollEvent(&event)) handleevents(&event);
 
 		// calculate FPS
 		fpscnt++;

--- a/platform/debug/makefile
+++ b/platform/debug/makefile
@@ -152,5 +152,4 @@ win:
 	make -f makefile.win
 
 clean:
-	-rm -f $(BUILDOBJS) $(TARGET) $(WINTARGET) $(WINRES_TRG)
-	-rmdir --ignore-fail-on-non-empty $(BUILD)
+	-rm -rf $(BUILDOBJS) $(TARGET) $(WINTARGET) $(WINRES_TRG) $(BUILD)


### PR DESCRIPTION
### Makefile

Use `rm -rf` when the `make` target is `clean` instead of `-rmdir --ignore-fail-on-non-empty $(BUILD)`

### GTK vs SDL event loop

The SDL event loop wasn't properly routing the user interaction events to the GTK event loop, but GTK does send events to SDL. Some [stackoverflow posts](https://stackoverflow.com/questions/8145806/embedding-sdl-into-gtk) indicate that there's probably a more robust way to handle this, but 'werks on my machine' as they say.